### PR TITLE
Support gray streams on ABCL.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1267,7 +1267,7 @@ or break them up into chunks).
 
 Ironclad includes support for several convenient stream abstractions
 based on Gray streams. Gray streams support in Ironclad is included
-for SBCL, CMUCL, OpenMCL, Lispworks, and Allegro.
+for SBCL, CMUCL, OpenMCL, Lispworks, ABCL, and Allegro.
 
 ** Octet streams
 

--- a/ironclad.asd
+++ b/ironclad.asd
@@ -40,7 +40,7 @@
                              (:file "macro-utils" :depends-on ("package"))
                              (:file "math" :depends-on ("package" "prng"))
                              ;; FIXME: make this depend on :FEATURE :IRONCLAD-GRAY-STREAMS
-                             #+(or lispworks sbcl openmcl cmu allegro)
+                             #+(or lispworks sbcl openmcl cmu allegro abcl)
                              (:file "octet-stream" :depends-on ("common" "conditions" "package"))
                              (:file "package")
                              (:file "padding" :depends-on ("common" "package"))
@@ -166,7 +166,9 @@
   (list* :ironclad-gray-streams
          (when (member :x86-64 *features*)
            '(:ironclad-fast-mod64-arithmetic)))
-  #-(or sbcl cmu allegro lispworks openmcl)
+  #+abcl
+  (list :ironclad-gray-streams)
+  #-(or sbcl cmu allegro lispworks openmcl abcl)
   nil)
 
 (macrolet ((do-silently (&body body)

--- a/src/octet-stream.lisp
+++ b/src/octet-stream.lisp
@@ -27,7 +27,8 @@
    #+openmcl gray:fundamental-binary-input-stream
    #+cmu ext:fundamental-binary-input-stream
    #+allegro excl:fundamental-binary-input-stream
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:fundamental-binary-input-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *binary-output-stream-class*
@@ -37,7 +38,8 @@
    #+openmcl gray:fundamental-binary-output-stream
    #+cmu ext:fundamental-binary-output-stream
    #+allegro excl:fundamental-binary-output-stream
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:fundamental-binary-output-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 ;;; FIXME: how to do CMUCL support for this?
@@ -48,7 +50,8 @@
    #+openmcl cl:stream-element-type
    #+cmu cl:stream-element-type
    #+allegro cl:stream-element-type
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl cl:stream-element-type
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-read-byte-function*
@@ -58,7 +61,8 @@
    #+openmcl gray:stream-read-byte
    #+cmu ext:stream-read-byte
    #+allegro excl:stream-read-byte
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-read-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-write-byte-function*
@@ -68,7 +72,8 @@
    #+openmcl gray:stream-write-byte
    #+cmu ext:stream-write-byte
    #+allegro excl:stream-write-byte
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-write-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-read-sequence-function*
@@ -78,7 +83,8 @@
    #+openmcl ccl:stream-read-vector
    #+cmu ext:stream-read-sequence
    #+allegro excl:stream-read-sequence
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-read-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-write-sequence-function*
@@ -88,7 +94,8 @@
    #+openmcl ccl:stream-write-vector
    #+cmu ext:stream-write-sequence
    #+allegro excl:stream-write-sequence
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-write-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-finish-output-function*
@@ -98,7 +105,8 @@
    #+openmcl gray:stream-finish-output
    #+cmu ext:stream-finish-output
    #+allegro excl:stream-finish-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-finish-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-force-output-function*
@@ -108,7 +116,8 @@
    #+openmcl gray:stream-force-output
    #+cmu ext:stream-force-output
    #+allegro excl:stream-force-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-force-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 
 (defvar *stream-clear-output-function*
@@ -118,7 +127,8 @@
    #+openmcl gray:stream-clear-output
    #+cmu ext:stream-clear-output
    #+allegro excl:stream-clear-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-clear-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error 'ironclad-error :format-control "octet streams not supported in this implementation")))
 )
 
@@ -172,6 +182,14 @@
        (,type
         ,@body)
        (t
+        (call-next-method))))
+  #+abcl
+  `(defmethod gray-streams:stream-read-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
         (call-next-method)))))
 
 (defmacro define-stream-write-sequence (specializer type &body body)
@@ -219,6 +237,14 @@
      (typecase seq
        (,type
         ,@body)
+       (t
+        (call-next-method))))
+  #+abcl
+  `(defmethod gray-streams:stream-write-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
        (t
         (call-next-method)))))
 

--- a/testing/testfuns.lisp
+++ b/testing/testfuns.lisp
@@ -152,7 +152,7 @@
     (when (mismatch result expected-digest)
       (error "fill-pointer'd ~A digest of ~S failed" digest-name input))))
 
-#+(or lispworks sbcl cmucl openmcl allegro)
+#+(or lispworks sbcl cmucl openmcl allegro abcl)
 (defun digest-test/stream (digest-name input expected-digest)
   (let* ((stream (crypto:make-digesting-stream digest-name)))
     (write-sequence input stream)
@@ -204,7 +204,7 @@
         (cons :digest-bit-test 'ignore-test)
         (cons :xof-digest-test 'ignore-test)))
 
-#+(or lispworks sbcl cmucl openmcl allegro)
+#+(or lispworks sbcl cmucl openmcl allegro abcl)
 (defparameter *digest-stream-tests*
   (list (cons :digest-test 'digest-test/stream)
         (cons :digest-bit-test 'ignore-test)


### PR DESCRIPTION
Gray streams on ABCL are working fine, therefore this patch enables them. All tests (still) run through.