### PR TITLE
Allow compilation without ASDF

### DIFF
--- a/ironclad.asd
+++ b/ironclad.asd
@@ -129,45 +129,6 @@
                               :components ((:file "fndb")
                                            (:file "x86oid-vm" :depends-on ("fndb"))))))))
 
-(defun ironclad-implementation-features ()
-  #+sbcl
-  (list* sb-c:*backend-byte-order*
-         (if (= sb-vm:n-word-bits 32)
-             :32-bit
-             :64-bit)
-         :ironclad-fast-mod32-arithmetic
-         :ironclad-gray-streams
-         (when (member :x86-64 *features*)
-           '(:ironclad-fast-mod64-arithmetic)))
-  #+cmu
-  (list (c:backend-byte-order c:*target-backend*)
-        (if (= vm:word-bits 32)
-            :32-bit
-            :64-bit)
-        :ironclad-fast-mod32-arithmetic
-        :ironclad-gray-streams)
-  #+allegro
-  (list :ironclad-gray-streams)
-  #+lispworks
-  (list :ironclad-gray-streams
-        ;; Disable due to problem reports from Lispworks users and
-        ;; non-obviousness of the fix.
-        #+nil
-        (when (not (member :lispworks4 *features*))
-          '(:ironclad-md5-lispworks-int32)))
-  #+openmcl
-  (list* :ironclad-gray-streams
-         (when (member :x86-64 *features*)
-           '(:ironclad-fast-mod64-arithmetic)))
-  #+abcl
-  (list :ironclad-gray-streams)
-  #+ecl
-  (list :ironclad-gray-streams)
-  #+clisp
-  (list :ironclad-gray-streams)
-  #-(or sbcl cmu allegro lispworks openmcl abcl ecl clisp)
-  nil)
-
 (macrolet ((do-silently (&body body)
              `(handler-bind ((style-warning #'muffle-warning)
                              ;; It's about as fast as we can make it,
@@ -181,8 +142,7 @@
     (let ((*print-base* 10)               ; INTERN'ing FORMAT'd symbols
           (*print-case* :upcase)
           #+sbcl (sb-ext:*inline-expansion-limit* (max sb-ext:*inline-expansion-limit* 1000))
-          #+cmu (ext:*inline-expansion-limit* (max ext:*inline-expansion-limit* 1000))
-          (*features* (append (ironclad-implementation-features) *features*)))
+          #+cmu (ext:*inline-expansion-limit* (max ext:*inline-expansion-limit* 1000)))
       (do-silently (call-next-method))))
 
   (defmethod perform :around ((op load-op) (c ironclad-source-file))

--- a/ironclad.asd
+++ b/ironclad.asd
@@ -5,21 +5,6 @@
 
 (cl:in-package #:ironclad-system)
 
-;;; easy-to-type readmacro for creating s-boxes and the like
-
-(defun array-reader (stream subchar arg)
-  (declare (ignore subchar))
-  (let ((array-data (read stream nil stream nil))
-        (array-element-type `(unsigned-byte ,arg)))
-    ;; FIXME: need to make this work for multi-dimensional arrays
-    `(make-array ,(length array-data) :element-type ',array-element-type
-                :initial-contents ',array-data)))
-
-(defparameter *ironclad-readtable*
-  (let ((readtable (copy-readtable nil)))
-    (set-dispatch-macro-character #\# #\@ #'array-reader readtable)
-    readtable))
-
 (defclass ironclad-source-file (cl-source-file) ())
 
 (defsystem "ironclad"
@@ -193,8 +178,7 @@
                              #+sbcl (sb-ext:compiler-note #'muffle-warning))
                 ,@body)))
   (defmethod perform :around ((op compile-op) (c ironclad-source-file))
-    (let ((*readtable* *ironclad-readtable*)
-          (*print-base* 10)               ; INTERN'ing FORMAT'd symbols
+    (let ((*print-base* 10)               ; INTERN'ing FORMAT'd symbols
           (*print-case* :upcase)
           #+sbcl (sb-ext:*inline-expansion-limit* (max sb-ext:*inline-expansion-limit* 1000))
           #+cmu (ext:*inline-expansion-limit* (max ext:*inline-expansion-limit* 1000))

--- a/src/ciphers/aes.lisp
+++ b/src/ciphers/aes.lisp
@@ -5,6 +5,7 @@
 ;;; key sizes is supported.
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 #+(and sbcl x86-64)
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/src/ciphers/blowfish.lisp
+++ b/src/ciphers/blowfish.lisp
@@ -2,6 +2,7 @@
 ;;;; blowfish.lisp -- implementation of Bruce Schneier's Blowfish block cipher
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (defconst +blowfish-n-rounds+ 16)
 

--- a/src/ciphers/cast5.lisp
+++ b/src/ciphers/cast5.lisp
@@ -2,6 +2,7 @@
 ;;;; cast5.lisp -- implementation of rfc2144 CAST5 algorithm
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 
 ;;; s-boxes

--- a/src/ciphers/des.lisp
+++ b/src/ciphers/des.lisp
@@ -6,6 +6,7 @@
 ;;; remain, so this is not the prettiest Common Lisp code ever.
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 
 ;;; the sboxes of DES

--- a/src/ciphers/misty1.lisp
+++ b/src/ciphers/misty1.lisp
@@ -2,6 +2,7 @@
 ;;;; misty1.lisp -- implementation of the MISTY1 block cipher from RFC 2994
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 
 ;;; required tables

--- a/src/ciphers/rc2.lisp
+++ b/src/ciphers/rc2.lisp
@@ -2,6 +2,7 @@
 ;;;; rc2.lisp -- implementation of the RC2 cipher algorithm from RFC 2268
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 ;;; RC2 accepts a 1-byte to 128-byte key.  But it also lets you specify
 ;;; an "effective key length" in bits, which effectively lets you have a

--- a/src/ciphers/square.lisp
+++ b/src/ciphers/square.lisp
@@ -4,6 +4,7 @@
 ;;; based on a public domain implementation by Paulo Baretto (FIXME!)
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (declaim (type (simple-array (unsigned-byte 8) (256))
                alogtable logtable))

--- a/src/ciphers/twofish.lisp
+++ b/src/ciphers/twofish.lisp
@@ -2,6 +2,7 @@
 ;;;; twofish.lisp -- implementation of Counterpane's Twofish AES candidate
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 
 ;;; various constant data arrays used by Twofish

--- a/src/digests/crc24.lisp
+++ b/src/digests/crc24.lisp
@@ -2,6 +2,7 @@
 ;;;; crc24.lisp
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (declaim (type (simple-array (unsigned-byte 32) (256)) +crc24-table+))
 (defconst +crc24-table+

--- a/src/digests/crc32.lisp
+++ b/src/digests/crc32.lisp
@@ -2,6 +2,7 @@
 ;;;; crc32.lisp
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (declaim (type (simple-array (unsigned-byte 32) (256)) +crc32-table+))
 (defconst +crc32-table+

--- a/src/digests/md2.lisp
+++ b/src/digests/md2.lisp
@@ -2,6 +2,7 @@
 ;;;; md2.lisp -- the MD2 message digest algorithm from RFC 1319
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (defconst +md2-permutation+
 #8@(41 46 67 201 162 216 124 1 61 54 84 161 236 240 6

--- a/src/digests/sha256.lisp
+++ b/src/digests/sha256.lisp
@@ -2,6 +2,7 @@
 ;;;; sha256.lisp -- implementation of SHA-2/256 from NIST
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (define-digest-registers (sha224 :endian :big :digest-registers 7)
   (a #xc1059ed8)

--- a/src/digests/sha512.lisp
+++ b/src/digests/sha512.lisp
@@ -2,6 +2,7 @@
 ;;; sha512.lisp -- implementation of SHA-384/512 from NIST
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 (define-digest-registers (sha384 :endian :big :size 8 :digest-registers 6)
   (a #xCBBB9D5DC1059ED8)

--- a/src/digests/skein.lisp
+++ b/src/digests/skein.lisp
@@ -2,6 +2,7 @@
 ;;;; skein.lisp -- implementation of the Skein hash functions
 
 (in-package :crypto)
+(in-ironclad-readtable)
 
 
 ;;; Parameter identifiers

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -153,3 +153,24 @@
            #:chacha #:chacha/12 #:chacha/8
            #:xchacha #:xchacha/12 #:xchacha/8
            #:sosemanuk))
+
+(in-package :crypto)
+
+;;; easy-to-type readmacro for creating s-boxes and the like
+
+(defun array-reader (stream subchar arg)
+  (declare (ignore subchar))
+  (let ((array-data (read stream nil stream nil))
+        (array-element-type `(unsigned-byte ,arg)))
+    ;; FIXME: need to make this work for multi-dimensional arrays
+    `(make-array ,(length array-data) :element-type ',array-element-type
+                :initial-contents ',array-data)))
+
+(defparameter *ironclad-readtable*
+  (let ((readtable (copy-readtable nil)))
+    (set-dispatch-macro-character #\# #\@ #'array-reader readtable)
+    readtable))
+
+(defmacro in-ironclad-readtable ()
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (setq *readtable* *ironclad-readtable*)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -174,3 +174,45 @@
 (defmacro in-ironclad-readtable ()
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (setq *readtable* *ironclad-readtable*)))
+
+(defun ironclad-implementation-features ()
+  #+sbcl
+  (list* sb-c:*backend-byte-order*
+         (if (= sb-vm:n-word-bits 32)
+             :32-bit
+             :64-bit)
+         :ironclad-fast-mod32-arithmetic
+         :ironclad-gray-streams
+         (when (member :x86-64 *features*)
+           '(:ironclad-fast-mod64-arithmetic)))
+  #+cmu
+  (list (c:backend-byte-order c:*target-backend*)
+        (if (= vm:word-bits 32)
+            :32-bit
+            :64-bit)
+        :ironclad-fast-mod32-arithmetic
+        :ironclad-gray-streams)
+  #+allegro
+  (list :ironclad-gray-streams)
+  #+lispworks
+  (list :ironclad-gray-streams
+        ;; Disable due to problem reports from Lispworks users and
+        ;; non-obviousness of the fix.
+        #+nil
+        (when (not (member :lispworks4 *features*))
+          '(:ironclad-md5-lispworks-int32)))
+  #+openmcl
+  (list* :ironclad-gray-streams
+         (when (member :x86-64 *features*)
+           '(:ironclad-fast-mod64-arithmetic)))
+  #+abcl
+  (list :ironclad-gray-streams)
+  #+ecl
+  (list :ironclad-gray-streams)
+  #+clisp
+  (list :ironclad-gray-streams)
+  #-(or sbcl cmu allegro lispworks openmcl abcl ecl clisp)
+  nil)
+
+(dolist (f (ironclad-implementation-features))
+  (pushnew f *features*))


### PR DESCRIPTION
These two commits move code from ironclad.asd to package.lisp to allow compilation of ironclad without having ASDF loaded.
There is no new code or lost code it is plain mv.